### PR TITLE
feat: common external og:image in theme

### DIFF
--- a/apify-docs-theme/package-lock.json
+++ b/apify-docs-theme/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apify/docs-theme",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apify/docs-theme",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "@docusaurus/theme-common": "^2.2.0",

--- a/apify-docs-theme/package.json
+++ b/apify-docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/docs-theme",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "./src/index.js",
   "files": [

--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -139,7 +139,7 @@ const themeConfig = ({
         additionalLanguages: ['docker', 'log'],
     },
     metadata: [],
-    image: 'img/apify_og_SDK.png',
+    image: 'https://apify.com/img/og/docs.png',
     footer: {
         links: [
             {


### PR DESCRIPTION
Theme now references an external `og:image` for all the v2 docs (https://apify.com/img/og/docs.png). This way, we don't have to maintain 5+ image copies in the respective repositories.