### PR TITLE
fix: breadcrumbs Home button

### DIFF
--- a/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.jsx
+++ b/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import { translate } from '@docusaurus/Translate';
+import IconHome from '@theme/Icon/Home';
+import styles from './styles.module.css';
+
+export default function HomeBreadcrumbItem() {
+    const baseUrl = useBaseUrl('/');
+
+    const currentPath = window.location.pathname.replace(`^${baseUrl}`, '');
+    const homeHref = useBaseUrl(currentPath.split('/')[1]);
+
+    return (
+        <li className="breadcrumbs__item">
+            <Link
+                aria-label={translate({
+                    id: 'theme.docs.breadcrumbs.home',
+                    message: 'Home page',
+                    description: 'The ARIA label for the home page in the breadcrumbs',
+                })}
+                className="breadcrumbs__link"
+                href={homeHref}>
+                <IconHome className={styles.breadcrumbHomeIcon} />
+            </Link>
+        </li>
+    );
+}

--- a/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/styles.module.css
+++ b/apify-docs-theme/src/theme/DocBreadcrumbs/Items/Home/styles.module.css
@@ -1,0 +1,7 @@
+.breadcrumbHomeIcon {
+  position: relative;
+  top: 1px;
+  vertical-align: top;
+  height: 1.1rem;
+  width: 1.1rem;
+}


### PR DESCRIPTION
Home is where the ~heart~ **first part of the path after the base url** is.

While this works nice in these docs (academy pages go to `/academy`, platform docs to `/platform`), it might break in the other projects where there are no `index.md` files (solution is very simple though, just renaming them should work).