### PR TITLE
fix: sitemap generation

### DIFF
--- a/apify-docs-theme/src/config.js
+++ b/apify-docs-theme/src/config.js
@@ -138,7 +138,7 @@ const themeConfig = ({
         darkTheme: require('prism-react-renderer/themes/dracula'),
         additionalLanguages: ['docker', 'log'],
     },
-    metadata: [{ name: 'robots', content: 'noindex, nofollow' }],
+    // metadata: [{ name: 'robots', content: 'noindex, nofollow' }],
     image: 'https://apify.com/img/og/docs.png',
     footer: {
         links: [


### PR DESCRIPTION
`docusaurus-plugin-sitemap` does not generate the sitemap when the `noindex` [meta tags are present](https://github.com/facebook/docusaurus/blob/6b618bc9e5fcc9d52d3aa49a9d447f4d7ea76d41/packages/docusaurus-plugin-sitemap/src/index.ts#L23). 

Also, we want to let search engines index the docs now, right?