### PR TITLE
docs: add missing page attribute in requestHandler

### DIFF
--- a/sources/academy/tutorials/node_js/dealing_with_dynamic_pages.md
+++ b/sources/academy/tutorials/node_js/dealing_with_dynamic_pages.md
@@ -149,9 +149,9 @@ import cheerio from 'cheerio';
 const BASE_URL = 'https://demo-webstore.apify.org';
 
 const crawler = new PuppeteerCrawler({
-    requestHandler: async ({ parseWithCheerio, request, page }) => {
+    requestHandler: async ({ parseWithCheerio, infiniteScroll }) => {
         // Add the utility function
-        await utils.puppeteer.infiniteScroll(page);
+        await infiniteScroll();
 
         const $ = await parseWithCheerio();
 

--- a/sources/academy/tutorials/node_js/dealing_with_dynamic_pages.md
+++ b/sources/academy/tutorials/node_js/dealing_with_dynamic_pages.md
@@ -149,7 +149,7 @@ import cheerio from 'cheerio';
 const BASE_URL = 'https://demo-webstore.apify.org';
 
 const crawler = new PuppeteerCrawler({
-    requestHandler: async ({ parseWithCheerio, request }) => {
+    requestHandler: async ({ parseWithCheerio, request, page }) => {
         // Add the utility function
         await utils.puppeteer.infiniteScroll(page);
 


### PR DESCRIPTION
I tried running the code example, and was getting an error that the `page` variable could not be found. 

The `page` attribute was left out of the object passed to `requestHandler` - leading to the error.